### PR TITLE
Implement spec file override feature

### DIFF
--- a/lib/atom-cfn-lint.js
+++ b/lib/atom-cfn-lint.js
@@ -39,6 +39,12 @@ export default {
         type: 'string'
       },
       description: 'Append Rules Directory (space deliminated)'
+    },
+    overrideSpecPath: {
+      title: 'Override Spec file path',
+      type: 'string',
+      description: '(Optional) Path to an override specfile json file',
+      default: ''
     }
   },
 
@@ -107,6 +113,11 @@ export default {
           for (i = 0; i < atom.config.get('atom-cfn-lint.appendRules').length; i++) {
             args = args.concat([atom.config.get('atom-cfn-lint.appendRules')[i]]);
           }
+        }
+
+        if (atom.config.get('atom-cfn-lint.overrideSpecPath') !== '') {
+          args = args.concat(['--override-spec']);
+          args = args.concat([atom.config.get('atom-cfn-lint.overrideSpecPath')]);
         }
 
         return helpers.exec(atom.config.get('atom-cfn-lint.cfnLintExecutablePath'), args, {cwd: require('path').dirname(file), ignoreExitCode: true}).then(output => {

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "atom-cfn-lint",
   "main": "./lib/atom-cfn-lint",
   "version": "0.4.0",
-  "description": "A short description of your package",
-  "keywords": [],
+  "description": "Validate CloudFormation yaml/json templates against the CloudFormation spec and additional checks. Includes checking valid values for resource properties and best practices.",
+  "keywords": ["linter", "AWS", "CloudFormation"],
   "repository": "https://github.com/awslabs/aws-cfn-lint-atom",
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
Implement spec file override feature (https://github.com/awslabs/cfn-python-lint#customise-specifications)

Added a setting to specify path the override file and pass it along if specified.

Along the way updated the package description, used the first paragraph from the cfn-lint readme... 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
