### PR TITLE
Add source url support

### DIFF
--- a/lib/atom-cfn-lint.js
+++ b/lib/atom-cfn-lint.js
@@ -197,9 +197,17 @@ module.exports = {
             const linenumberend = parseInt(match.Location.End.LineNumber, 10) - 1
             const columnnumberend = parseInt(match.Location.End.ColumnNumber, 10) - 1
 
+            souce_url = "";
+
+            // Rule sources are added in version 0.3.3 of cfn-lint
+            if (match.Rule.hasOwnProperty('Source')) {
+              souce_url = match.Rule.Source.toLowerCase()
+            }
+
             toReturn.push({
               severity: match.Level.toLowerCase(),
               excerpt: match.Message,
+              url: souce_url,
               location: {
                 file,
                 position: [[linenumber, columnnumber], [linenumberend, columnnumberend]],


### PR DESCRIPTION
Since the latest release of cfn-lint (`0.3.3`) the rules contain a `source_url` that contains a link to the source of the rule. 

This PR adds the url to the feedback to the user, build in a way that it also works with older versions of cfn-lint

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
