### PR TITLE
Remove toLowerCase of url's

### DIFF
--- a/lib/atom-cfn-lint.js
+++ b/lib/atom-cfn-lint.js
@@ -200,7 +200,7 @@ module.exports = {
 
             // Rule sources are added in version 0.3.3 of cfn-lint
             if (Object.prototype.hasOwnProperty.call(match.Rule, 'Source')) {
-              sourceUrl = match.Rule.Source.toLowerCase()
+              sourceUrl = match.Rule.Source
             }
 
             toReturn.push({


### PR DESCRIPTION
AWS Url's are case sensitive, so lowercasing this returns 404

e.g. `https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html` becomes `https://docs.aws.amazon.com/awscloudformation/latest/userguide/parameters-section-structure.html`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
