### PR TITLE
Improve severity mapping

### DIFF
--- a/lib/atom-cfn-lint.js
+++ b/lib/atom-cfn-lint.js
@@ -203,8 +203,24 @@ module.exports = {
               sourceUrl = match.Rule.Source
             }
 
+
+            // Map the linter severity into the Atom linter values (error, warning, info)
+            // See: https://steelbrain.me/linter/types/linter-message-v2.html
+            let linterSeverity
+
+            switch (match.Level) {
+              case 'Informational':
+                linterSeverity = 'info'
+                break
+              case 'Warning':
+                linterSeverity = 'warning'
+                break
+              default:
+                linterSeverity = 'error'
+            }
+
             toReturn.push({
-              severity: match.Level.toLowerCase(),
+              severity: linterSeverity,
               excerpt: match.Message,
               url: sourceUrl,
               location: {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atom-cfn-lint",
   "main": "./lib/atom-cfn-lint",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Validate CloudFormation yaml/json templates against the CloudFormation spec and additional checks. Includes checking valid values for resource properties and best practices.",
   "keywords": [
     "linter",


### PR DESCRIPTION
Improve the severity mapping to properly handle the new `Informational` level in the linter.

See: https://github.com/awslabs/cfn-python-lint/blob/master/src/cfnlint/formatters/__init__.py#L56

FYI:
Not changing the String output in the linter because every IDE have different linter severities. VsCode calls has `Information` ([Source](https://github.com/awslabs/aws-cfn-lint-visual-studio-code/blob/master/server/src/server.ts#L100)) and Sublime does not know about Information level warnings at all ([Source](https://github.com/SublimeLinter/SublimeLinter/issues/1475))

Info looks like this:
![image](https://user-images.githubusercontent.com/35613489/50591107-23c88700-0e8e-11e9-9330-7fc77dd7f376.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
